### PR TITLE
移除 load_boston 函数的引入以防止报错

### DIFF
--- a/实验二：岭回归与Lasso回归实验/Ridge&Lasso.ipynb
+++ b/实验二：岭回归与Lasso回归实验/Ridge&Lasso.ipynb
@@ -56,7 +56,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "from sklearn.datasets import load_boston, fetch_california_housing\n",
+    "from sklearn.datasets import fetch_california_housing\n",
     "from sklearn.model_selection import train_test_split\n",
     "from sklearn.metrics import r2_score, mean_squared_error\n",
     "from sklearn.preprocessing import StandardScaler\n",


### PR DESCRIPTION
load_boston 在 scikit-learn 1.2+ 版本中已被移除，并且笔记下文中也没有使用。